### PR TITLE
whitespace typo in init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,5 +30,5 @@ class google_chrome(
   validate_re($version, ['^stable','^unstable','^beta'])
 
   class { 'google_chrome::config': } ->
-  class { 'google_chrome::install' : }
+  class { 'google_chrome::install': }
 }


### PR DESCRIPTION
(change "class { 'google_chrome::install' : }" to "class { 'google_chrome::install': }", without space before final colon)
